### PR TITLE
Removed duplicate Package.json

### DIFF
--- a/Package.json
+++ b/Package.json
@@ -1,9 +1,0 @@
-{
-    "name": "com.demigiant.dotween",
-    "displayName": "DOTween",
-    "description": "A Unity C# animation/tween engine. HOTween v2.",
-    "version": "1.2.32",
-    "author": "Daniele Giardini",
-    "dependencies": {}
-  }
-  

--- a/Package.json.meta
+++ b/Package.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 8bc0ca5a5d217de49b86d6b67d857baa
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Removed duplicate Package.json file as Unity was getting conflicts in Linux platform. 
Fixes [#406](https://github.com/Demigiant/dotween/issues/406) in upstream